### PR TITLE
Update repo for user access

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ $ sematic run advanced/main.py --build -- /advanced/data/message.txt
 ```
 
 This example also shows how to package data files and pass arguments to the pipeline
-execution.
+execution, and how to configure a custom Docker client connection to the Docker server.

--- a/advanced/docker/Dockerfile
+++ b/advanced/docker/Dockerfile
@@ -4,18 +4,18 @@ WORKDIR /
 
 # Configure apt
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && apt install -y software-properties-common
+RUN apt-get update -y && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 
 # Install python3.9
-RUN apt update -y && apt install -y python3.9
+RUN apt-get update -y && apt-get install -y python3.9
 RUN rm /usr/bin/python3
 RUN ln -s /usr/bin/python3.9 /usr/bin/python3
 RUN ln -s /usr/bin/python3.9 /usr/bin/python
 
 # Install pip3
-RUN apt update -y && apt install -y python3-pip
-RUN apt update -y && apt install --reinstall -y python3.9-distutils
+RUN apt-get update -y && apt-get install -y python3-pip
+RUN apt-get update -y && apt-get install --reinstall -y python3.9-distutils
 
 # Install all pipeline requirements, including Sematic itself
 COPY requirements.txt requirements.txt

--- a/advanced/main.yaml
+++ b/advanced/main.yaml
@@ -1,8 +1,8 @@
 version: 1
 image_script: "scripts/build_image.sh"
 push:
-  registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
-  repository: "sematic-dev"
+  registry: <image push registry>
+  repository: <image push repository>
   tag_suffix: "example_docker_advanced"
 docker:
   base_url: "unix://var/run/docker.sock"

--- a/advanced/main.yaml
+++ b/advanced/main.yaml
@@ -1,6 +1,9 @@
-version: 0
+version: 1
 image_script: "advanced/scripts/build_image.sh"
 push:
   registry: <image push registry>
   repository: <image push repository>
-  tag_suffix: <optional image push tag suffix>
+  tag_suffix: "example_docker_advanced"
+docker:
+  base_url: "unix://var/run/docker.sock"
+  tls: true

--- a/advanced/main.yaml
+++ b/advanced/main.yaml
@@ -1,8 +1,8 @@
 version: 1
-image_script: "advanced/scripts/build_image.sh"
+image_script: "scripts/build_image.sh"
 push:
-  registry: <image push registry>
-  repository: <image push repository>
+  registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
+  repository: "sematic-dev"
   tag_suffix: "example_docker_advanced"
 docker:
   base_url: "unix://var/run/docker.sock"

--- a/advanced/pipeline.py
+++ b/advanced/pipeline.py
@@ -1,7 +1,7 @@
 from sematic import func
 
 
-@func
+@func(inline=False)
 def pipeline(data_file_path: str) -> str:
     with open(data_file_path, "r") as f:
         return f.readline()

--- a/intermediate/main.yaml
+++ b/intermediate/main.yaml
@@ -2,10 +2,10 @@ version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"
-  requirements: "requirements.txt"
-  data: ["intermediate/data/message.txt"]
-  src: ["intermediate/**.py"]
+  requirements: "//requirements.txt"
+  data: ["data/message.txt"]
+  src: ["**.py"]
 push:
-  registry: <image push registry>
-  repository: <image push repository>
+  registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
+  repository: "sematic-dev"
   tag_suffix: "example_docker_intermediate"

--- a/intermediate/main.yaml
+++ b/intermediate/main.yaml
@@ -6,6 +6,6 @@ build:
   data: ["data/message.txt"]
   src: ["**.py"]
 push:
-  registry: "558717131297.dkr.ecr.us-west-2.amazonaws.com"
-  repository: "sematic-dev"
+  registry: <image push registry>
+  repository: <image push repository>
   tag_suffix: "example_docker_intermediate"

--- a/intermediate/main.yaml
+++ b/intermediate/main.yaml
@@ -1,4 +1,4 @@
-version: 0
+version: 1
 base_uri: "sematicai/sematic-worker-base:latest@sha256:bea3926876a3024c33fe08e0a6b2c0377a7eb600d7b3061a3f3f39d711152e3c"
 build:
   platform: "linux/amd64"
@@ -8,4 +8,4 @@ build:
 push:
   registry: <image push registry>
   repository: <image push repository>
-  tag_suffix: <optional image push tag suffix>
+  tag_suffix: "example_docker_intermediate"

--- a/intermediate/pipeline.py
+++ b/intermediate/pipeline.py
@@ -1,7 +1,7 @@
 from sematic import func
 
 
-@func
+@func(inline=False)
 def pipeline(data_file_path: str) -> str:
     with open(data_file_path, "r") as f:
         return f.readline()


### PR DESCRIPTION
This PR bumps the version of the build config files, making them usable by the version of the Build system from https://github.com/sematic-ai/sematic/pull/815, which exposes it up to the users.

Also switches to `apt-get`, as explained in https://github.com/sematic-ai/sematic/pull/834, and updates paths to build file-relative paths, in order to work with https://github.com/sematic-ai/sematic/pull/850.
