### PR TITLE
Update pip for the Advanced example

### DIFF
--- a/advanced/docker/Dockerfile
+++ b/advanced/docker/Dockerfile
@@ -13,13 +13,22 @@ RUN rm /usr/bin/python3
 RUN ln -s /usr/bin/python3.9 /usr/bin/python3
 RUN ln -s /usr/bin/python3.9 /usr/bin/python
 
-# Install pip3
-RUN apt-get update -y && apt-get install -y python3-pip
-RUN apt-get update -y && apt-get install --reinstall -y python3.9-distutils
+# Install pip; work around https://github.com/pypa/pip/issues/10851
+RUN apt-get update -y && apt-get install --reinstall --no-install-recommends -y python3.9-distutils
+RUN which pip || \
+( \
+export PYTHONDONTWRITEBYTECODE=1 && \
+apt-get update -y && \
+apt-get install -y --no-install-recommends wget && \
+wget --no-verbose -O get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+python3 get-pip.py && \
+rm get-pip.py && \
+unset PYTHONDONTWRITEBYTECODE \
+)
 
 # Install all pipeline requirements, including Sematic itself
 COPY requirements.txt requirements.txt
-RUN pip3 install --no-cache -r requirements.txt
+RUN pip install --no-cache-dir --ignore-installed --root-user-action=ignore -r requirements.txt
 
 # Copy the data files
 COPY advanced/data/message.txt advanced/data/message.txt


### PR DESCRIPTION
The Advanced example started failing with:

```bash
$ sematic run --log-level debug --build advanced/main.py -- /advanced/data/message.txt
[...]
Step 7/8 : RUN python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )
---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
---> Running in fd7f33465195
Traceback (most recent call last):

  File "<string>", line 1, in <module>

ModuleNotFoundError: No module named 'sematic'


Usage:
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...


no such option: --root-user-action

2023-07-19 05:50:34,624  [ERROR] sematic.plugins.building.docker_builder: Image build error details: '{'code': 2, 'message': 'The command \'/bin/sh -c python3 -c "import sematic" || ( export PYTHONDONTWRITEBYTECODE=1 && pip install --no-cache-dir --ignore-installed --root-user-action=ignore sematic && unset PYTHONDONTWRITEBYTECODE )\' returned a non-zero code: 2'}'
[...]
```

This is caused by the existing Dockerfile resulting in the installation of `pip` `22.0.2`, which does not support the `--root-user-action` parameter.

This PR updates the Advanced case Dockerfile to install the latest version of `pip`.
