### PR TITLE
Switch from Resolver to Runner

### DIFF
--- a/advanced/main.py
+++ b/advanced/main.py
@@ -7,6 +7,6 @@ from advanced.pipeline import pipeline
 
 if __name__ == "__main__":
     future = pipeline(sys.argv[1]).set(
-        name="Advanced Docker Example Pipeline", tags=["examples", "docker", "advanced"]
+        name="Advanced Docker Example Pipeline", tags=["example", "docker", "advanced"]
     )
     print(CloudRunner().run(future))

--- a/advanced/main.py
+++ b/advanced/main.py
@@ -1,9 +1,12 @@
 import sys
 
-from sematic import CloudResolver
+from sematic import CloudRunner
 
 from advanced.pipeline import pipeline
 
 
 if __name__ == "__main__":
-    print(pipeline(sys.argv[1]).resolve(CloudResolver()))
+    future = pipeline(sys.argv[1]).set(
+        name="Advanced Docker Example Pipeline", tags=["examples", "docker", "advanced"]
+    )
+    print(CloudRunner().run(future))

--- a/basic/main.py
+++ b/basic/main.py
@@ -1,4 +1,4 @@
-from sematic import func, LocalResolver
+from sematic import func, LocalRunner
 
 
 @func
@@ -7,4 +7,7 @@ def pipeline() -> str:
 
 
 if __name__ == "__main__":
-    print(pipeline().resolve(LocalResolver()))
+    future = pipeline().set(
+        name="Basic Example Pipeline", tags=["examples", "local", "advanced"]
+    )
+    print(LocalRunner().run(future))

--- a/basic/main.py
+++ b/basic/main.py
@@ -8,6 +8,6 @@ def pipeline() -> str:
 
 if __name__ == "__main__":
     future = pipeline().set(
-        name="Basic Example Pipeline", tags=["examples", "local", "advanced"]
+        name="Basic Example Pipeline", tags=["example", "local", "advanced"]
     )
     print(LocalRunner().run(future))

--- a/intermediate/main.py
+++ b/intermediate/main.py
@@ -8,6 +8,6 @@ from intermediate.pipeline import pipeline
 if __name__ == "__main__":
     future = pipeline(sys.argv[1]).set(
         name="Intermediate Docker Example Pipeline",
-        tags=["examples", "docker", "intermediate"],
+        tags=["example", "docker", "intermediate"],
     )
     print(CloudRunner().run(future))

--- a/intermediate/main.py
+++ b/intermediate/main.py
@@ -1,9 +1,13 @@
 import sys
 
-from sematic import CloudResolver
+from sematic import CloudRunner
 
 from intermediate.pipeline import pipeline
 
 
 if __name__ == "__main__":
-    print(pipeline(sys.argv[1]).resolve(CloudResolver()))
+    future = pipeline(sys.argv[1]).set(
+        name="Intermediate Docker Example Pipeline",
+        tags=["examples", "docker", "intermediate"],
+    )
+    print(CloudRunner().run(future))


### PR DESCRIPTION
Switches the examples from using `*Resolver`. to user `*Runner`.

Also adds tags and pipeline names for a better user experience.

<img width="382" alt="image" src="https://github.com/sematic-ai/example_docker/assets/1894533/4b42692c-08cd-4aba-a525-c19fbfa5ebee">

<img width="403" alt="image" src="https://github.com/sematic-ai/example_docker/assets/1894533/c0280e39-f700-471d-a8d6-bd1debebf688">

<img width="416" alt="image" src="https://github.com/sematic-ai/example_docker/assets/1894533/d8e45b26-4152-4ef1-826c-a7a9e1aed1ab">
